### PR TITLE
User status

### DIFF
--- a/app/controllers/public/posts_controller.rb
+++ b/app/controllers/public/posts_controller.rb
@@ -9,7 +9,7 @@ class Public::PostsController < ApplicationController
 
   def index
     @post = Post.new
-    @posts = Post.all
+    @posts = Post.visible_to(current_user)
   end
 
   def show

--- a/app/controllers/public/users_controller.rb
+++ b/app/controllers/public/users_controller.rb
@@ -18,7 +18,7 @@ class Public::UsersController < ApplicationController
   private
   
   def user_params
-    params.require(:user).permit(:account_name, :name, :first_name, :last_name, :email)
+    params.require(:user).permit(:account_name, :name, :first_name, :last_name, :email, :status)
   end
   
   def set_user

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -4,16 +4,18 @@ class Post < ApplicationRecord
   has_many :notifications, dependent: :destroy
   belongs_to :user
   
+  #post.statusがopen           → 誰でも見れる投稿
+  #             followers_only → フォロワーだけ見れる投稿
   enum status: { open: 0, followers_only: 1 }
   
   before_create :set_status
   
   has_one_attached :image
   
-  #投稿を公開とフォローワーだけに分けて取得する
+  #post.statusを条件で分けて取得
   scope :visible_to, -> (user) {
     if user.present?
-      where(status: [:open, :followers_only])
+      where(status: [:open])
         .or(where(user: user))
         .or(where(user_id: user.following_ids, status: :followers_only))
     else
@@ -22,6 +24,7 @@ class Post < ApplicationRecord
     end
   }
   
+  #いいねがされているかどうか
   def favorited_by?(user)
     favorites.exists?(user_id: user.id)
   end
@@ -89,7 +92,7 @@ class Post < ApplicationRecord
   
   private
 
-  #ユーザーのステータスを投稿のステータスに変換して保存する
+  #ユーザーステータスを投稿ステータスに変換して保存する
   def set_status
     if user.status == 'closed'
       self.status = 'followers_only'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,6 +18,8 @@ class User < ApplicationRecord
   has_many :active_notifications, class_name: 'Notification', foreign_key: 'visitor_id', dependent: :destroy
   has_many :passive_notifications, class_name: 'Notification', foreign_key: 'visited_id', dependent: :destroy
   
+  #user.statusがopen   → 誰でも見れる
+  #             closed → フォロワーだけ見れる
   enum status: { open: 0, closed: 1 }
   
   after_update :update_post_statuses, if: :saved_change_to_status?
@@ -33,7 +35,7 @@ class User < ApplicationRecord
     status == "open"
   end
 
-  def private?
+  def closed?
     status == "closed"
   end
 
@@ -82,7 +84,7 @@ class User < ApplicationRecord
   
   private
 
-  #ユーザーのステータスに連動してそのユーザーの投稿ステータスを変更する
+  #ユーザーステータスに連動してそのユーザーの投稿ステータスを更新する
   def update_post_statuses
     posts.each do |post|
       if status == "closed"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,11 +18,25 @@ class User < ApplicationRecord
   has_many :active_notifications, class_name: 'Notification', foreign_key: 'visitor_id', dependent: :destroy
   has_many :passive_notifications, class_name: 'Notification', foreign_key: 'visited_id', dependent: :destroy
   
+  enum status: { open: 0, closed: 1 }
+  
+  after_update :update_post_statuses, if: :saved_change_to_status?
+  
   has_one_attached :profile_image
   
   def get_profile_image
     (profile_image.attached?) ? profile_image : 'no_image.jpg'
   end
+  
+  #ユーザーの公開・非公開
+  def open?
+    status == "open"
+  end
+
+  def private?
+    status == "closed"
+  end
+
   
   #URLにアカウント名を表示する
   def to_param
@@ -63,6 +77,19 @@ class User < ApplicationRecord
         action: 0
       )
       notification.save if notification.valid?
+    end
+  end
+  
+  private
+
+  #ユーザーのステータスに連動してそのユーザーの投稿ステータスを変更する
+  def update_post_statuses
+    posts.each do |post|
+      if status == "closed"
+        post.update(status: "followers_only")
+      else
+        post.update(status: status)
+      end
     end
   end
   

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -34,7 +34,11 @@
               公開・非公開
             </td>
             <td>
-              <%= @user.is_disclose ? '公開中' : '非公開' %>
+              <% if @user.status == 'open' %>
+                公開
+              <% else %>
+                非公開
+              <% end %>
             </td>
           </tr>
           <tr>

--- a/app/views/public/users/edit.html.erb
+++ b/app/views/public/users/edit.html.erb
@@ -43,13 +43,13 @@
                 <td></td>
                 <td>
                   <%= f.radio_button :status, "open", class: "form-check-input" %>
-                  <%= f.label :status_public, class: "form-check-label" do %>
+                  <%= f.label :status_open, class: "form-check-label" do %>
                     公開
                   <% end %>
                 </td>
                 <td>
                   <%= f.radio_button :status, "closed", class: "form-check-input" %>
-                  <%= f.label :status_private, class: "form-check-label" do %>
+                  <%= f.label :status_closed, class: "form-check-label" do %>
                     非公開
                   <% end %>
                 </td>

--- a/app/views/public/users/edit.html.erb
+++ b/app/views/public/users/edit.html.erb
@@ -38,6 +38,22 @@
                   <%= f.email_field :email %>
                 </td>
               </tr>
+              <tr>
+                <td>ステータス</td>
+                <td></td>
+                <td>
+                  <%= f.radio_button :status, "open", class: "form-check-input" %>
+                  <%= f.label :status_public, class: "form-check-label" do %>
+                    公開
+                  <% end %>
+                </td>
+                <td>
+                  <%= f.radio_button :status, "closed", class: "form-check-input" %>
+                  <%= f.label :status_private, class: "form-check-label" do %>
+                    非公開
+                  <% end %>
+                </td>
+              </tr>
             </tbody>
           </table>
           <%= f.submit '変更する' %>

--- a/app/views/public/users/show.html.erb
+++ b/app/views/public/users/show.html.erb
@@ -31,6 +31,16 @@
               <%= @user.experience_point %>
             </td>
           </tr>
+          <tr>
+            <td>ステータス</td>
+            <td>
+              <% if @user.status == 'open' %>
+                公開
+              <% else %>
+                非公開
+              <% end %>
+            </td>
+          </tr>
         </tbody>
       </table>
       <% if @user == current_user %>

--- a/db/migrate/20230509114645_change_column_to_users.rb
+++ b/db/migrate/20230509114645_change_column_to_users.rb
@@ -1,0 +1,6 @@
+class ChangeColumnToUsers < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :users, :is_disclose, :boolean
+    add_column :users, :status, :integer, default: 0, null: false
+  end
+end

--- a/db/migrate/20230509114700_add_status_to_posts.rb
+++ b/db/migrate/20230509114700_add_status_to_posts.rb
@@ -1,0 +1,5 @@
+class AddStatusToPosts < ActiveRecord::Migration[6.1]
+  def change
+    add_column :posts, :status, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_09_011012) do
+ActiveRecord::Schema.define(version: 2023_05_09_114700) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -99,6 +99,7 @@ ActiveRecord::Schema.define(version: 2023_05_09_011012) do
     t.text "body", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "status", default: 0, null: false
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
@@ -121,10 +122,10 @@ ActiveRecord::Schema.define(version: 2023_05_09_011012) do
     t.string "last_name", null: false
     t.integer "level", default: 1, null: false
     t.float "experience_point", default: 0.0, null: false
-    t.boolean "is_disclose", default: true, null: false
     t.boolean "is_deleted", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "status", default: 0, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,12 +6,12 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-# Admin.create!(
-#  email: ENV['ADMIN_EMAIL'],
-#  password: ENV['ADMIN_PASSWORD']
-# )
+ Admin.create!(
+  email: ENV['ADMIN_EMAIL'],
+  password: ENV['ADMIN_PASSWORD']
+ )
 
 # Create level settings for levels 2 to 10
-# (2..10).each do |level|
-#  LevelSetting.create(level: level, threshold: level * 100)
-# end
+ (2..10).each do |level|
+  LevelSetting.create(level: level, threshold: level * 100)
+ end


### PR DESCRIPTION
ユーザーにステータス絡むを追加 
投稿にユーザーステータスに紐ずく投稿ステータスを追加
投稿一覧画面にて誰でも見れる投稿とユーザーのフォロワーだけ見れる投稿に分けて表示するようにした。