### PR TITLE
Layout admin

### DIFF
--- a/app/controllers/public/posts_controller.rb
+++ b/app/controllers/public/posts_controller.rb
@@ -14,8 +14,8 @@ class Public::PostsController < ApplicationController
   end
 
   def index
+    @posts = Post.visible_to(current_user).order(created_at: :desc).paginate(page: params[:page], per_page: 5)
     @post = Post.new
-    @posts = Post.page(params[:page]).order(created_at: :desc)
   end
 
   def show

--- a/app/controllers/public/users_controller.rb
+++ b/app/controllers/public/users_controller.rb
@@ -2,7 +2,7 @@ class Public::UsersController < ApplicationController
   before_action :set_user
 
   def show
-    @posts = @user.posts.page(params[:page]).order(created_at: :desc)
+    @posts = @user.posts.order(created_at: :desc).paginate(page: params[:page], per_page: 5)
     @favorites = @user.favorited_posts
   end
 

--- a/app/controllers/public/users_controller.rb
+++ b/app/controllers/public/users_controller.rb
@@ -3,7 +3,7 @@ class Public::UsersController < ApplicationController
 
   def show
     @posts = @user.posts.order(created_at: :desc).paginate(page: params[:page], per_page: 5)
-    @favorites = @user.favorited_posts
+    @favorites = @user.favorited_posts.order(created_at: :desc).paginate(page: params[:page], per_page: 5)
   end
 
 

--- a/app/controllers/public/users_controller.rb
+++ b/app/controllers/public/users_controller.rb
@@ -3,9 +3,10 @@ class Public::UsersController < ApplicationController
 
   def show
     @posts = @user.posts.order(created_at: :desc).paginate(page: params[:page], per_page: 5)
-    @favorites = @user.favorited_posts.order(created_at: :desc).paginate(page: params[:page], per_page: 5)
+    favorites = Favorite.valid_favorites(@user)
+    favorited_posts = Post.where(id: favorites.pluck(:post_id))
+    @visible_favorite_posts = favorited_posts.visible_to(current_user).order(created_at: :desc).paginate(page: params[:page], per_page: 5)
   end
-
 
   def update
     if @user.update(user_params)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,4 +6,18 @@ module ApplicationHelper
     percentage = (current_user.experience_point.to_f / threshold.to_f) * 100
     percentage > 100 ? "100%" : "#{percentage.round}%"
   end
+  
+  #user.statusによってユーザー詳細画面の表示を分岐する
+  def can_view_profile?(current_user, user)
+    if user == current_user
+      true
+    elsif user.status == "open"
+      true
+    elsif user.status == "closed" && current_user.following?(user)
+      true
+    else
+      false
+    end
+  end
+  
 end

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,6 +1,12 @@
 class Favorite < ApplicationRecord
   belongs_to :user
   belongs_to :post
+
+  scope :valid_favorites, ->(user_id) do
+    joins(:post)
+      .where(is_cancel: false)
+      .where(user_id: user_id)
+  end
   
   #いいねを取り消す（理論削除）
   def unlike

--- a/app/views/public/posts/_favorited-list.html.erb
+++ b/app/views/public/posts/_favorited-list.html.erb
@@ -1,6 +1,6 @@
-<div>
-  <% @favorites.each do |post| %>
-    <div class="border p-2">
+<div class="scroll-list jscroll">
+  <% favorites.each do |post| %>
+    <div class="border p-2 m-1">
       <div class="d-flex">
         <div class="text-center">
           <%= image_tag post.user.get_profile_image, class: "rounded-circle", size: '50x50' %>
@@ -9,9 +9,6 @@
         </div>
         <div class="d-flex align-items-center font-weight-bold ml-2 mb-4">
           <%= post.user.name %>
-        </div>
-        <div class="d-flex align-items-center text-muted ml-2 mb-4">
-          <%= post.user.account_name %>
         </div>
       </div>
       <div style="word-wrap: break-word;">
@@ -37,4 +34,5 @@
       </div>
     </div>
   <% end %>
+  <%= paginate favorites %>
 </div>

--- a/app/views/public/posts/_favorited-list.html.erb
+++ b/app/views/public/posts/_favorited-list.html.erb
@@ -1,5 +1,5 @@
 <div class="scroll-list jscroll">
-  <% favorites.each do |post| %>
+  <% visible_favorite_posts.each do |post| %>
     <div class="border p-2 m-1">
       <div class="d-flex">
         <div class="text-center">
@@ -34,5 +34,5 @@
       </div>
     </div>
   <% end %>
-  <%= paginate favorites %>
+  <%= paginate visible_favorite_posts %>
 </div>

--- a/app/views/public/posts/_index.html.erb
+++ b/app/views/public/posts/_index.html.erb
@@ -1,6 +1,6 @@
 <div class="scroll-list jscroll">
   <% posts.each do |post| %>
-    <div class="border p-2">
+    <div class="border p-2 m-1">
       <div class="d-flex">
         <div class="text-center">
           <%= image_tag post.user.get_profile_image, class: "rounded-circle", size: '50x50' %>
@@ -9,9 +9,6 @@
         </div>
         <div class="d-flex align-items-center font-weight-bold ml-2 mb-4">
           <%= post.user.name %>
-        </div>
-        <div class="d-flex align-items-center text-muted ml-2 mb-4">
-          <%= post.user.account_name %>
         </div>
       </div>
       <div style="word-wrap: break-word;">

--- a/app/views/public/posts/index.html.erb
+++ b/app/views/public/posts/index.html.erb
@@ -26,16 +26,11 @@
     $(window).resize(function() {
       setHeight();
     });
-  });
-
-  $('#posts').on('scroll', function() {
-    scrollHeight = $(document).height();
-    scrollPosition = $('#posts').height() + $('#posts').scrollTop();
-    if ((scrollHeight - scrollPosition) / scrollHeight <= 0.05) {
-      $('#posts .jscroll').jscroll({
-        contentSelector: '.scroll-list',
-        nextSelector: 'span.next:last a'
-      });
-    }
+    
+    $('#posts').jscroll({
+      contentSelector: '.scroll-list',
+      nextSelector: 'span.next:last a',
+      loadingHtml: '<div class="text-center"><i class="fas fa-spinner fa-spin"></i> Loading...</div>'
+    });
   });
 </script>

--- a/app/views/public/posts/index.html.erb
+++ b/app/views/public/posts/index.html.erb
@@ -4,7 +4,7 @@
       <%= render 'layouts/info' %>
     </div>
     <div class="col-6">
-      <div id="posts" style="overflow-y: scroll; height: 500px;">
+      <div class="posts-scroll" style="overflow-y: scroll; height: 500px;">
         <%= render 'index', posts: @posts %>
       </div>
     </div>
@@ -17,17 +17,18 @@
 </div>
 
 <script>
+  //無限スクロール
   $(document).ready(function() {
     function setHeight() {
       windowHeight = $(window).innerHeight();
-      $('#posts').css('height', windowHeight);
+      $('.posts-scroll').css('height', windowHeight);
     };
     setHeight();
     $(window).resize(function() {
       setHeight();
     });
     
-    $('#posts').jscroll({
+    $('.posts-scroll').jscroll({
       contentSelector: '.scroll-list',
       nextSelector: 'span.next:last a',
       loadingHtml: '<div class="text-center"><i class="fas fa-spinner fa-spin"></i> Loading...</div>'

--- a/app/views/public/users/show.html.erb
+++ b/app/views/public/users/show.html.erb
@@ -46,7 +46,7 @@
           <% end %>
         </div>
       </div>
-      <% if current_user.following?(@user) || @user == current_user %>
+      <% if can_view_profile?(current_user, @user) %>
         <div>
           <ul class="list-group list-group-horizontal" id="tab-menu">
             <li class="list-group-item list-group-item-action text-center"><a href="#tab1" class="active nav-link">投稿</a></li>
@@ -55,7 +55,9 @@
           
           <div id="tab-contents">
             <div id="tab1" class="tab">
-              <%= render 'public/posts/index', posts: @posts %>
+              <div id="posts" style="overflow-y: scroll; height: 500px;">
+                <%= render 'public/posts/index', posts: @posts %>
+              </div>
             </div>
     
             <div id="tab2" class="tab">
@@ -84,5 +86,22 @@
     $(this).addClass("active");
     $($(this).attr("href")).show();
     event.preventDefault();
+  });
+  
+  $(document).ready(function() {
+    function setHeight() {
+      windowHeight = $(window).innerHeight();
+      $('#posts').css('height', windowHeight);
+    };
+    setHeight();
+    $(window).resize(function() {
+      setHeight();
+    });
+    
+    $('#posts').jscroll({
+      contentSelector: '.scroll-list',
+      nextSelector: 'span.next:last a',
+      loadingHtml: '<div class="text-center"><i class="fas fa-spinner fa-spin"></i> Loading...</div>'
+    });
   });
 </script>

--- a/app/views/public/users/show.html.erb
+++ b/app/views/public/users/show.html.erb
@@ -55,14 +55,14 @@
           
           <div id="tab-contents">
             <div id="tab1" class="tab">
-              <div class="posts-scroll" style="overflow-y: scroll; height: 500px;">
-                <%= render 'public/posts/index', posts: @posts %>
+              <div class="posts-list" style="overflow-y: scroll; height: 500px;">
+                <%= render 'public/posts/index', posts: @posts, list_class: 'post-list' %>
               </div>
             </div>
-    
+          
             <div id="tab2" class="tab">
-              <div class="posts-scroll" style="overflow-y: scroll; height: 500px;">
-                <%= render 'public/posts/favorited-list', favorites: @favorites %>
+              <div class="favorite-list" style="overflow-y: scroll; height: 500px;">
+                <%= render 'public/posts/favorited-list', visible_favorite_posts: @visible_favorite_posts, list_class: 'favorite-list' %>
               </div>
             </div>
           </div>
@@ -95,14 +95,31 @@
   $(document).ready(function() {
     function setHeight() {
       windowHeight = $(window).innerHeight();
-      $('.posts-scroll').css('height', windowHeight);
+      $('.posts-list').css('height', windowHeight);
     };
     setHeight();
     $(window).resize(function() {
       setHeight();
     });
     
-    $('.posts-scroll').jscroll({
+    $('.posts-list').jscroll({
+      contentSelector: '.scroll-list',
+      nextSelector: 'span.next:last a',
+      loadingHtml: '<div class="text-center"><i class="fas fa-spinner fa-spin"></i> Loading...</div>'
+    });
+  });
+  
+  $(document).ready(function() {
+    function setHeight() {
+      windowHeight = $(window).innerHeight();
+      $('.favorite-list').css('height', windowHeight);
+    };
+    setHeight();
+    $(window).resize(function() {
+      setHeight();
+    });
+    
+    $('.favorite-list').jscroll({
       contentSelector: '.scroll-list',
       nextSelector: 'span.next:last a',
       loadingHtml: '<div class="text-center"><i class="fas fa-spinner fa-spin"></i> Loading...</div>'

--- a/app/views/public/users/show.html.erb
+++ b/app/views/public/users/show.html.erb
@@ -55,13 +55,15 @@
           
           <div id="tab-contents">
             <div id="tab1" class="tab">
-              <div id="posts" style="overflow-y: scroll; height: 500px;">
+              <div class="posts-scroll" style="overflow-y: scroll; height: 500px;">
                 <%= render 'public/posts/index', posts: @posts %>
               </div>
             </div>
     
             <div id="tab2" class="tab">
-              <%= render 'public/posts/favorited-list', favorites: @favorites %>
+              <div class="posts-scroll" style="overflow-y: scroll; height: 500px;">
+                <%= render 'public/posts/favorited-list', favorites: @favorites %>
+              </div>
             </div>
           </div>
         </div>
@@ -78,6 +80,7 @@
 
 
 <script>
+  //タブで表示切り替え
   $('#tab-contents .tab[id != "tab1"]').hide();
   
   $('#tab-menu a').on('click', function(event) {
@@ -87,18 +90,19 @@
     $($(this).attr("href")).show();
     event.preventDefault();
   });
-  
+
+  //無限スクロール
   $(document).ready(function() {
     function setHeight() {
       windowHeight = $(window).innerHeight();
-      $('#posts').css('height', windowHeight);
+      $('.posts-scroll').css('height', windowHeight);
     };
     setHeight();
     $(window).resize(function() {
       setHeight();
     });
     
-    $('#posts').jscroll({
+    $('.posts-scroll').jscroll({
       contentSelector: '.scroll-list',
       nextSelector: 'span.next:last a',
       loadingHtml: '<div class="text-center"><i class="fas fa-spinner fa-spin"></i> Loading...</div>'


### PR DESCRIPTION
ユーザー詳細ページの投稿一覧といいね一覧で表示の際に不具合が発生している。
内容はタブで投稿一覧といいね一覧を分けて表示するようにしているが現在は投稿一覧の表示のところにいいね一覧も表示されてしまう。