### PR TITLE
[Add] registrations post placeholder

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -4,7 +4,7 @@ class Post < ApplicationRecord
   has_many :notifications, dependent: :destroy
   belongs_to :user
   
-  validates :body, presence: true, length: { maximum: 50 }
+  validates :body, presence: true, length: { maximum: 100 }
   
   #post.statusがopen           → 誰でも見れる
   #             followers_only → フォロワーだけ見れる

--- a/app/views/public/posts/_new.html.erb
+++ b/app/views/public/posts/_new.html.erb
@@ -5,7 +5,10 @@
       <%= form_with model: Post.new, url: posts_path, local: true do |f| %>
         <%= f.hidden_field :user_id, value: current_user.id %>
         <div class="modal-body">
-          <%= f.text_area :body, placeholder: 'ここに投稿内容を入力してください', class: 'border-0 form-control' %>
+          <%= f.text_area :body, placeholder: "ここに投稿内容を入力してください\n *最大100文字まで", class: 'border-0 form-control', id: 'post-body' %>
+          <div class="d-flex justify-content-end text-secondary">
+            <span id="char-count">0/100</span>
+          </div>
           <div>
             <div class="d-flex justify-content-end">
               <span class="cancel-icon btn" style="display: none;" onclick="cancelImagePreview()">
@@ -32,14 +35,13 @@
   </div>
 </div>
 
-<!-- 画像プレビュー表示のスクリプト -->
 <script>
   function cancelImagePreview() {
     $('#image-preview').html(''); // 画像プレビューを削除
     $('.cancel-icon').hide(); // 取り消しのボタンを非表示
     $('.img_field').val(''); // ファイル選択の値をクリア
   }
-
+  // 画像プレビューの表示
   $(function() {
     function readURL(input) {
       if (input.files && input.files[0]) {
@@ -70,14 +72,32 @@
         reader.readAsDataURL(input.files[0]);
       }
     }
-    
+
     // 取り消しのボタンがクリックされたときに画像プレビューを削除
     $(document).on('click', '.cancel-icon', function() {
       cancelImagePreview();
     });
-    
+
     $(document).on('change', '.img_field', function(){
       readURL(this);
     });
+  });
+
+  // 文字数のカウントの表示
+  const textarea = document.getElementById("post-body");
+  const charCount = document.getElementById("char-count");
+
+  textarea.addEventListener("input", function() {
+    const maxLength = 100;
+    const currentLength = textarea.value.length;
+    const remainingLength = maxLength - currentLength;
+
+    charCount.textContent = currentLength + "/" + maxLength;
+
+    if (remainingLength < 0) {
+      charCount.style.color = "red";
+    } else {
+      charCount.style.color = "inherit";
+    }
   });
 </script>

--- a/app/views/public/registrations/new.html.erb
+++ b/app/views/public/registrations/new.html.erb
@@ -13,7 +13,7 @@
                   <div class="input-group-prepend">
                     <span class="input-group-text p-1">@</span>
                   </div>
-                  <%= f.text_field :account_name, class: "form-control" %>
+                  <%= f.text_field :account_name, class: "form-control", placeholder: "半角英数字のみ" %>
                 </td>
               </tr>
               <tr>

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe 'Postモデルのテスト', type: :model do
         post.body = ''
         is_expected.to eq false
       end
-      it '50文字以下であること: 50文字は〇' do
-        post.body = Faker::Lorem.characters(number: 50)
+      it '50文字以下であること: 100文字は〇' do
+        post.body = Faker::Lorem.characters(number: 100)
         is_expected.to eq true
       end
-      it '50文字以下であること: 51文字は×' do
-        post.body = Faker::Lorem.characters(number: 51)
+      it '50文字以下であること: 101文字は×' do
+        post.body = Faker::Lorem.characters(number: 101)
         is_expected.to eq false
       end
     end


### PR DESCRIPTION
ユーザーの新規投稿フォーム[アカウント名]の文字制限が分かるようにしました。
投稿(post)の入力フォームbodyに文字数制限があることが分かるようにしました。
投稿(post)の文字数制限を50文字から100文字に変更