### PR TITLE
[Add] comment text_area placeholder

### DIFF
--- a/app/controllers/public/comments_controller.rb
+++ b/app/controllers/public/comments_controller.rb
@@ -10,14 +10,18 @@ class Public::CommentsController < ApplicationController
       redirect_back fallback_location: root_path, alert: "不適切なコメントの為、投稿に失敗しました。"
       return
     end
-    
-    if comment.save
-      post.create_notification_comment!(current_user, comment.id)
-      @post = Post.find(params[:post_id])
-      @comment = Comment.new
+    if comment.valid?
+      if comment.save
+        post.create_notification_comment!(current_user, comment.id)
+        @post = Post.find(params[:post_id])
+        @comment = Comment.new
+      else
+        redirect_back fallback_location: root_path, alert: "コメントの投稿に失敗しました。"
+      end
     else
-      redirect_back fallback_location: root_path, alert: "コメントの投稿に失敗しました。"
-    end
+      flash[:alert] = comment.errors.full_messages.join(", ")
+      redirect_back fallback_location: root_path
+    end 
   end
   
   def destroy

--- a/app/views/public/comments/_form.html.erb
+++ b/app/views/public/comments/_form.html.erb
@@ -1,8 +1,11 @@
 <div class="form-group m-2">
   <%= form_with model: [post, comment], local: false do |f| %>
     <div class="d-flex">
-      <div class="flex-grow-1 d-flex align-items-center justify-content-center">
-        <%= f.text_field :body, rows: '5', placeholder: "コメントを送ろう!", class: "form-control" %>
+      <div class="flex-grow-1 d-flex align-items-center justify-content-center border rounded">
+        <%= f.text_field :body, rows: '5', placeholder: "コメントを送ろう!(最大20文字まで)", class: "form-control border-0", id: 'comment-body' %>
+        <div class="d-flex justify-content-end text-secondary">
+          <span id="comment-char-count" class="p-2">0/20</span>
+        </div>
       </div>
       <div class="d-flex align-items-center justify-content-center m-1">
         <%= f.submit "送信する", class: "btn btn-outline-success" %>
@@ -10,3 +13,33 @@
     </div>
   <% end %>
 </div>
+
+<script>
+  // 文字数のカウントの表示
+  $(document).ready(function() {
+    const textCommentArea = document.getElementById("comment-body");
+    const commentCharCount = document.getElementById("comment-char-count");
+  
+    // 初期表示時に文字数をカウントして反映
+    const initialLength = textCommentArea.value.length;
+    commentCharCount.textContent = initialLength + "/20";
+  
+    textCommentArea.addEventListener("input", function() {
+      countCharacters();
+    });
+  
+    function countCharacters() {
+      const maxLength = 20;
+      const currentLength = textCommentArea.value.length;
+      const remainingLength = maxLength - currentLength;
+  
+      commentCharCount.textContent = currentLength + "/" + maxLength;
+  
+      if (remainingLength < 0) {
+        commentCharCount.style.color = "red";
+      } else {
+        commentCharCount.style.color = "inherit";
+      }
+    }
+  });
+</script>

--- a/app/views/public/posts/_edit.html.erb
+++ b/app/views/public/posts/_edit.html.erb
@@ -5,7 +5,7 @@
       <%= form_with model: @post, url: post_path, method: :patch, local: true do |f| %>
         <%= f.hidden_field :user_id, value: current_user.id %>
         <div class="modal-body">
-          <%= f.text_area :body, placeholder: 'ここに投稿内容を入力してください', class: 'border-0 form-control', id: 'post-edit-body' %>
+          <%= f.text_area :body, rows: 3, placeholder: "ここに投稿内容を入力してください。\n最大100文字まで", class: 'border-0 form-control', id: 'post-edit-body' %>
           <div class="d-flex justify-content-end text-secondary">
             <span id="char-edit-count">0/100</span>
           </div>

--- a/app/views/public/posts/_new.html.erb
+++ b/app/views/public/posts/_new.html.erb
@@ -5,7 +5,7 @@
       <%= form_with model: Post.new, url: posts_path, local: true do |f| %>
         <%= f.hidden_field :user_id, value: current_user.id %>
         <div class="modal-body">
-          <%= f.text_area :body, placeholder: "ここに投稿内容を入力してください\n *最大100文字まで", class: 'border-0 form-control', id: 'post-body' %>
+          <%= f.text_area :body, rows: 3, placeholder: "ここに投稿内容を入力してください。\n最大100文字まで", class: 'border-0 form-control', id: 'post-body' %>
           <div class="d-flex justify-content-end text-secondary">
             <span id="char-count">0/100</span>
           </div>

--- a/app/views/public/posts/show.html.erb
+++ b/app/views/public/posts/show.html.erb
@@ -55,7 +55,7 @@
           </div>
         </div>
       </div>
-      <div class="comment-form">
+      <div class="comment-form m-2">
         <%= render 'public/comments/form', post: @post, comment: @comment %>
       </div>
       <div class="comment-<%= @comment.id %>" style="overflow-y: auto; max-height: calc(100vh - 300px);">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -9,6 +9,8 @@ ja:
         email: メールアドレス
       post:
         body: 投稿内容
+      comment:
+        body: コメント
     models:
       user: ユーザー
   devise:


### PR DESCRIPTION
コメント(comment)の入力フォームに文字数制限があることが分かるようにしました。
コメントの投稿機能で文字数制限のバリデーションエラーの場合、文字数制限のエラーが分かるメッセージを表示